### PR TITLE
WIP: Components 'UseURL' to listen on all interfaces (0.0.0.0).

### DIFF
--- a/VectorContainers/Broker.API/Program.cs
+++ b/VectorContainers/Broker.API/Program.cs
@@ -49,7 +49,7 @@ namespace Broker.API
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder
-                .UseUrls("http://localhost:2001")
+                .UseUrls("http://0.0.0.0:2001")
                 .UseStartup<Startup>()
                 .UseSerilog();
             });

--- a/VectorContainers/Coin.API/Program.cs
+++ b/VectorContainers/Coin.API/Program.cs
@@ -49,7 +49,7 @@ namespace Coin.API
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder
-                .UseUrls("http://localhost:5001")
+                .UseUrls("http://0.0.0.0:5001")
                 .UseStartup<Startup>()
                 .UseSerilog();
             });

--- a/VectorContainers/Membership.API/Program.cs
+++ b/VectorContainers/Membership.API/Program.cs
@@ -49,7 +49,7 @@ namespace Membership.API
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder
-                .UseUrls("http://localhost:4001")
+                .UseUrls("http://0.0.0.0:4001")
                 .UseStartup<Startup>()
                 .UseSerilog();
             });

--- a/VectorContainers/MessagePool.API/Program.cs
+++ b/VectorContainers/MessagePool.API/Program.cs
@@ -49,7 +49,7 @@ namespace MessagePool.API
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder
-                .UseUrls("http://localhost:6001")
+                .UseUrls("http://0.0.0.0:6001")
                 .UseStartup<Startup>()
                 .UseSerilog();
             });

--- a/VectorContainers/Onion.API/Program.cs
+++ b/VectorContainers/Onion.API/Program.cs
@@ -49,7 +49,7 @@ namespace Onion.API
             .ConfigureWebHostDefaults(webBuilder =>
             {
                 webBuilder
-                .UseUrls("http://localhost:3001")
+                .UseUrls("http://0.0.0.0:3001")
                 .UseStartup<Startup>()
                 .UseSerilog();
             });


### PR DESCRIPTION
This is needed in order to run the containers in a multi-container arrangement. For example, it needs to be at least `http://172.17.0.1:nnnn` when `docker-compose` is used to orchestrate the containers.

Ideally, this patch would allow the UseURL parameter to be user-configurable in the 'appsettings.json'. 